### PR TITLE
yargs version update to resolve the prototype issue related to prev. …

### DIFF
--- a/packages/svgicon-viewer/package-lock.json
+++ b/packages/svgicon-viewer/package-lock.json
@@ -1,0 +1,121 @@
+{
+    "name": "@yzfe/svgicon-viewer",
+    "version": "1.0.2",
+    "lockfileVersion": 1,
+    "requires": true,
+    "dependencies": {
+        "ansi-regex": {
+            "version": "5.0.0",
+            "resolved": "https://smbuild.jfrog.io/artifactory/api/npm/siteminder-npm/ansi-regex/-/ansi-regex-5.0.0.tgz",
+            "integrity": "sha1-OIU59VF5vzkznIGvMKZU1p+Hy3U="
+        },
+        "ansi-styles": {
+            "version": "4.3.0",
+            "resolved": "https://smbuild.jfrog.io/artifactory/api/npm/siteminder-npm/ansi-styles/-/ansi-styles-4.3.0.tgz",
+            "integrity": "sha1-7dgDYornHATIWuegkG7a00tkiTc=",
+            "requires": {
+                "color-convert": "^2.0.1"
+            }
+        },
+        "cliui": {
+            "version": "7.0.4",
+            "resolved": "https://smbuild.jfrog.io/artifactory/api/npm/siteminder-npm/cliui/-/cliui-7.0.4.tgz",
+            "integrity": "sha1-oCZe5lVHb8gHrqnfPfjfd4OAi08=",
+            "requires": {
+                "string-width": "^4.2.0",
+                "strip-ansi": "^6.0.0",
+                "wrap-ansi": "^7.0.0"
+            }
+        },
+        "color-convert": {
+            "version": "2.0.1",
+            "resolved": "https://smbuild.jfrog.io/artifactory/api/npm/siteminder-npm/color-convert/-/color-convert-2.0.1.tgz",
+            "integrity": "sha1-ctOmjVmMm9s68q0ehPIdiWq9TeM=",
+            "requires": {
+                "color-name": "~1.1.4"
+            }
+        },
+        "color-name": {
+            "version": "1.1.4",
+            "resolved": "https://smbuild.jfrog.io/artifactory/api/npm/siteminder-npm/color-name/-/color-name-1.1.4.tgz",
+            "integrity": "sha1-wqCah6y95pVD3m9j+jmVyCbFNqI="
+        },
+        "emoji-regex": {
+            "version": "8.0.0",
+            "resolved": "https://smbuild.jfrog.io/artifactory/api/npm/siteminder-npm/emoji-regex/-/emoji-regex-8.0.0.tgz",
+            "integrity": "sha1-6Bj9ac5cz8tARZT4QpY79TFkzDc="
+        },
+        "escalade": {
+            "version": "3.1.1",
+            "resolved": "https://smbuild.jfrog.io/artifactory/api/npm/siteminder-npm/escalade/-/escalade-3.1.1.tgz",
+            "integrity": "sha1-2M/ccACWXFoBdLSoLqpcBVJ0LkA="
+        },
+        "get-caller-file": {
+            "version": "2.0.5",
+            "resolved": "https://smbuild.jfrog.io/artifactory/api/npm/siteminder-npm/get-caller-file/-/get-caller-file-2.0.5.tgz",
+            "integrity": "sha1-T5RBKoLbMvNuOwuXQfipf+sDH34="
+        },
+        "is-fullwidth-code-point": {
+            "version": "3.0.0",
+            "resolved": "https://smbuild.jfrog.io/artifactory/api/npm/siteminder-npm/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+            "integrity": "sha1-8Rb4Bk/pCz94RKOJl8C3UFEmnx0="
+        },
+        "require-directory": {
+            "version": "2.1.1",
+            "resolved": "https://smbuild.jfrog.io/artifactory/api/npm/siteminder-npm/require-directory/-/require-directory-2.1.1.tgz",
+            "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I="
+        },
+        "string-width": {
+            "version": "4.2.2",
+            "resolved": "https://smbuild.jfrog.io/artifactory/api/npm/siteminder-npm/string-width/-/string-width-4.2.2.tgz",
+            "integrity": "sha1-2v1PlVmnWFz7pSnGoKT3NIjr1MU=",
+            "requires": {
+                "emoji-regex": "^8.0.0",
+                "is-fullwidth-code-point": "^3.0.0",
+                "strip-ansi": "^6.0.0"
+            }
+        },
+        "strip-ansi": {
+            "version": "6.0.0",
+            "resolved": "https://smbuild.jfrog.io/artifactory/api/npm/siteminder-npm/strip-ansi/-/strip-ansi-6.0.0.tgz",
+            "integrity": "sha1-CxVx3XZpzNTz4G4U7x7tJiJa5TI=",
+            "requires": {
+                "ansi-regex": "^5.0.0"
+            }
+        },
+        "wrap-ansi": {
+            "version": "7.0.0",
+            "resolved": "https://smbuild.jfrog.io/artifactory/api/npm/siteminder-npm/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+            "integrity": "sha1-Z+FFz/UQpqaYS98RUpEdadLrnkM=",
+            "requires": {
+                "ansi-styles": "^4.0.0",
+                "string-width": "^4.1.0",
+                "strip-ansi": "^6.0.0"
+            }
+        },
+        "y18n": {
+            "version": "5.0.8",
+            "resolved": "https://smbuild.jfrog.io/artifactory/api/npm/siteminder-npm/y18n/-/y18n-5.0.8.tgz",
+            "integrity": "sha1-f0k00PfKjFb5UxSTndzS3ZHOHVU="
+        },
+        "yargs": {
+            "version": "17.0.1",
+            "resolved": "https://smbuild.jfrog.io/artifactory/api/npm/siteminder-npm/yargs/-/yargs-17.0.1.tgz",
+            "integrity": "sha1-ahztTtXuCziAELqf1nr4O5Ni4Ls=",
+            "requires": {
+                "cliui": "^7.0.2",
+                "escalade": "^3.1.1",
+                "get-caller-file": "^2.0.5",
+                "require-directory": "^2.1.1",
+                "string-width": "^4.2.0",
+                "y18n": "^5.0.5",
+                "yargs-parser": "^20.2.2"
+            }
+        },
+        "yargs-parser": {
+            "version": "20.2.7",
+            "resolved": "https://smbuild.jfrog.io/artifactory/api/npm/siteminder-npm/yargs-parser/-/yargs-parser-20.2.7.tgz",
+            "integrity": "sha1-Yd+FwRPt+1p6TjbriqYO9CPLyQo="
+        }
+    }
+}

--- a/packages/svgicon-viewer/package.json
+++ b/packages/svgicon-viewer/package.json
@@ -37,7 +37,7 @@
         "fastify-static": "^3.2.0",
         "glob": "^7.1.6",
         "portfinder": "^1.0.28",
-        "yargs": "^13.2.1"
+        "yargs": "^17.0.1"
     },
     "publishConfig": {
         "registry": "https://registry.npmjs.org",


### PR DESCRIPTION
…versions of y18n

the current version of yargs used a version of y18n that has Prototype Pollution
issues
https://www.npmjs.com/advisories/1654
As mentioned in the abive doco this has been resolved in 5.0.5 or later versions of y18n.
yargs version 17.0.1 uses the v5.0.5 of y18n which should resolve this issue