### PR TITLE
221: add export of type definitions to package.json

### DIFF
--- a/packages/vite-plugin-svgicon/package.json
+++ b/packages/vite-plugin-svgicon/package.json
@@ -6,7 +6,8 @@
     "exports": {
         ".": {
             "import": "./dist/index.mjs",
-            "require": "./dist/index.js"
+            "require": "./dist/index.js",
++            "types": "./dist/index.d.ts"
         }
     },
     "license": "MIT",


### PR DESCRIPTION
Using patch package the change was tested already.
The PR fixes the "TS7016: Could not find a declaration file for module" error.